### PR TITLE
Add check for upstream remote first

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -2,6 +2,7 @@
 'use strict';
 const meow = require('meow');
 const gitRemoteOriginUrl = require('git-remote-origin-url');
+const gitRemoteUpstreamUrl = require('git-remote-upstream-url');
 const githubUrlFromGit = require('github-url-from-git');
 const opn = require('opn');
 
@@ -11,9 +12,13 @@ meow(`
 	  $ gh
 `);
 
-gitRemoteOriginUrl().then(url => {
+gitRemoteUpstreamUrl().then(url => {
 	opn(githubUrlFromGit(url), {wait: false});
 }).catch(() => {
-	console.error(`Couldn't find the remote origin URL. Ensure it's set and you're in a repo.\n\n  $ git remote add origin https://github.com/user/repo.git`);
-	process.exit(1);
+	gitRemoteOriginUrl().then(url => {
+		opn(githubUrlFromGit(url), {wait: false});
+	}).catch(() => {
+		console.error(`Couldn't find the remote origin or upstream URLs. Ensure they're set and you're in a repo.\n\n  $ git remote add origin https://github.com/user/repo.git`);
+		process.exit(1);
+	});
 });

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   ],
   "dependencies": {
     "git-remote-origin-url": "^2.0.0",
+    "git-remote-upstream-url": "^2.0.0",
     "github-url-from-git": "^1.4.0",
     "meow": "^3.7.0",
     "opn": "^3.0.3"

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,7 @@
 
 > Open the GitHub page of the repo in the current directory
 
+This will open the GitHub page for the current directory. It will attempt to open the upstream branch first; if there is one it will open that, else it will open the fork's page.
 
 ## Install
 
@@ -24,6 +25,7 @@ $ gh-home --help
 ## Related
 
 - [npm-home](https://github.com/sindresorhus/npm-home) - Open the npm page of a package
+- [gh-upstream](https://github.com/RichardLitt/gh-upstream) - Open the GitHub page of the upstream remote for the repo in the current directory
 
 
 ## License


### PR DESCRIPTION
If there is an upstream, it makes more sense to open that than the fork, I think. I've added that functionality. 

I've also pointed to [RichardLitt/gh-upstream](//github.com/RichardLitt/gh-upstream) and used [RichardLitt/git-remote-upstream-url](//github.com/RichardLitt/git-remote-upstream-url) which I created to serve this purpose, too. 
