### PR TITLE
Add flags for opening pull requests and issues of a GitHub repo

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -11,21 +11,53 @@ const cli = meow(`
 	Usage
 	  $ gh-home [repo | user/repo]
 
+	Options
+	  --prs  	Open the pull requsts of a GitHub repo
+	  --issues 	Open the issues of a GitHub repo
+	
 	Examples
 	  $ gh-home
 	  $ gh-home myrepo
 	  $ gh-home avajs/ava
-`);
+	  $ gh-home --issues
+	  $ gh-home --prs
+`, {
+	flags: {
+		prs: {
+			type: 'boolean',
+			default: false,
+			alias: 'p'
+		},
+		issues: {
+			type: 'boolean',
+			default: false,
+			alias: 'i'
+		}
+	}
+});
 
 const repo = cli.input[0];
+const options = cli.flags;
+
+const openUrl = (url, options) => {
+	if (options.prs) {
+		return open(`${url}/pulls`);
+	}
+
+	if (options.issues) {
+		return open(`${url}/issues`);
+	}
+
+	return open(url);
+};
 
 (async () => {
 	if (repo) {
 		if (repo.includes('/')) {
-			await open(`https://github.com/${repo}`);
+			await openUrl(`https://github.com/${repo}`, options);
 		} else {
 			const {stdout: user} = await execa('git', ['config', '--global', 'github.user']);
-			await open(`https://github.com/${user}/${repo}`);
+			await openUrl(`https://github.com/${user}/${repo}`, options);
 		}
 	} else {
 		let url;
@@ -47,6 +79,6 @@ const repo = cli.input[0];
 			process.exit(1);
 		}
 
-		await open(url);
+		await openUrl(url, options);
 	}
 })();

--- a/cli.js
+++ b/cli.js
@@ -41,11 +41,9 @@ const options = cli.flags;
 
 const openUrl = (url, options) => {
 	if (options.prs) {
-		return open(`${url}/pulls`);
-	}
-
-	if (options.issues) {
-		return open(`${url}/issues`);
+		url = `${url}/pulls`;
+	} else if (options.issues) {
+		url = `${url}/issues`;
 	}
 
 	return open(url);

--- a/cli.js
+++ b/cli.js
@@ -12,8 +12,8 @@ const cli = meow(`
 	  $ gh-home [repo | user/repo]
 
 	Options
-	  --prs  	Open the pull requsts of a GitHub repo
-	  --issues 	Open the issues of a GitHub repo
+	  --prs -p	   Open the pull requests of a GitHub repo
+	  --issues -i  Open the issues of a GitHub repo
 	
 	Examples
 	  $ gh-home

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ $ gh-home --help
     $ gh-home myrepo
     $ gh-home avajs/ava
     $ gh-home --issues
-	  $ gh-home --prs
+    $ gh-home --prs
 ```
 
 ## Tips

--- a/readme.md
+++ b/readme.md
@@ -18,10 +18,16 @@ $ gh-home --help
   Usage
     $ gh-home [repo | user/repo]
 
+  Options
+	  --prs -p	   Open the pull requests of a GitHub repo
+	  --issues -i  Open the issues of a GitHub repo
+
   Examples
     $ gh-home
     $ gh-home myrepo
     $ gh-home avajs/ava
+    $ gh-home --issues
+	  $ gh-home --prs
 ```
 
 ## Tips


### PR DESCRIPTION
Add two flags, `--prs` and `--issues`, to open the pull request and issues tab of a GitHub repository respectively.

Closes #9 

